### PR TITLE
Feature/machine dependent filters

### DIFF
--- a/src/badger/factory.py
+++ b/src/badger/factory.py
@@ -39,9 +39,9 @@ def scan_plugins(root):
 
     # Do not scan local algorithms if option disabled
     if LOAD_LOCAL_ALGO:
-        ptype_list = ['algorithm', 'interface', 'environment']
+        ptype_list = ['algorithm', 'interface', 'environment', 'tag']
     else:
-        ptype_list = ['interface', 'environment']
+        ptype_list = ['interface', 'environment', 'tag']
         factory['algorithm'] = {}
 
     for ptype in ptype_list:
@@ -65,7 +65,7 @@ def scan_plugins(root):
 
 def load_plugin(root, pname, ptype):
     assert ptype in ['algorithm', 'interface',
-                     'environment'], f'Invalid plugin type {ptype}'
+                     'environment', 'tag'], f'Invalid plugin type {ptype}'
 
     proot = os.path.join(root, f'{ptype}s')
 
@@ -89,6 +89,8 @@ def load_plugin(root, pname, ptype):
 
     if ptype == 'algorithm':
         plugin = [module.optimize, configs]
+    if ptype == 'tag':
+        plugin = [module.machine_tags, configs]
     elif ptype == 'interface':
         params = module.Interface.model_json_schema()['properties']
         params = {name: get_value_or_none(info, 'default')
@@ -135,7 +137,7 @@ def load_plugin(root, pname, ptype):
 
 def load_docs(root, pname, ptype):
     assert ptype in ['algorithm', 'interface',
-                     'environment'], f'Invalid plugin type {ptype}'
+                     'environment', 'tag'], f'Invalid plugin type {ptype}'
 
     proot = os.path.join(root, f'{ptype}s')
 
@@ -237,10 +239,12 @@ def get_intf(name):
 def get_env(name):
     return get_plug(BADGER_PLUGIN_ROOT, name, 'environment')
 
+def get_tag(name):
+    return get_plug(BADGER_PLUGIN_ROOT, name, 'tag')
+
 
 def list_algo():
     algos = list(generators.keys())
-
     return sorted(algos)
 
 
@@ -250,6 +254,9 @@ def list_intf():
 
 def list_env():
     return sorted(BADGER_FACTORY['environment'])
+
+def list_tag():
+    return sorted(BADGER_FACTORY['tag'])
 
 
 BADGER_FACTORY = scan_plugins(BADGER_PLUGIN_ROOT)

--- a/src/badger/gui/default/components/filter_cbox.py
+++ b/src/badger/gui/default/components/filter_cbox.py
@@ -5,13 +5,29 @@ from .collapsible_box import CollapsibleBox
 
 class BadgerFilterBox(CollapsibleBox):
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, parent=None, title="", tags = []):
+        super().__init__(parent, title)
+        
+        self.tags = tags
 
         self.init_ui()
 
     def init_ui(self):
         vbox = QVBoxLayout()
+        
+        # Machine filter
+        mach = QWidget()
+        hbox_mach = QHBoxLayout(mach)
+        hbox_mach.setContentsMargins(0, 0, 0, 0)
+        lbl = QLabel('Machine')
+        lbl.setFixedWidth(64)
+        self.cb_mach = cb_mach = QComboBox()
+        cb_mach.setItemDelegate(QStyledItemDelegate())
+        cb_mach.addItems(['']+self.tags)
+        cb_mach.setCurrentIndex(-1)
+        hbox_mach.addWidget(lbl)
+        hbox_mach.addWidget(cb_mach, 1)
+        vbox.addWidget(mach)
 
         # Obj filter
         obj = QWidget()
@@ -21,7 +37,7 @@ class BadgerFilterBox(CollapsibleBox):
         lbl.setFixedWidth(64)
         self.cb_obj = cb_obj = QComboBox()
         cb_obj.setItemDelegate(QStyledItemDelegate())
-        cb_obj.addItems(['', 'HXR', 'SXR'])
+        cb_obj.addItems([''])
         cb_obj.setCurrentIndex(-1)
         hbox_obj.addWidget(lbl)
         hbox_obj.addWidget(cb_obj, 1)
@@ -35,15 +51,7 @@ class BadgerFilterBox(CollapsibleBox):
         lbl.setFixedWidth(64)
         self.cb_reg = cb_reg = QComboBox()
         cb_reg.setItemDelegate(QStyledItemDelegate())
-        cb_reg.addItems([
-            '',
-            'LI21:201, 211, 271, 278',
-            'LI26:201, 301, 401, 501',
-            'LI26:601, 701, 801, 901',
-            'IN20:361, 371, 425, 441, 511, 525',
-            'LTUH:620, 640, 660, 680',
-            'LTUS:620, 640, 660, 680',
-        ])
+        cb_reg.addItems([''])
         cb_reg.setCurrentIndex(-1)
         hbox_reg.addWidget(lbl)
         hbox_reg.addWidget(cb_reg, 1)
@@ -57,13 +65,7 @@ class BadgerFilterBox(CollapsibleBox):
         lbl.setFixedWidth(64)
         self.cb_gain = cb_gain = QComboBox()
         cb_gain.setItemDelegate(QStyledItemDelegate())
-        cb_gain.addItems([
-            '',
-            '1',
-            '2',
-            '4',
-            '8',
-        ])
+        cb_gain.addItems([''])
         cb_gain.setCurrentIndex(-1)
         hbox_gain.addWidget(lbl)
         hbox_gain.addWidget(cb_gain, 1)

--- a/src/badger/gui/default/components/filter_cbox.py
+++ b/src/badger/gui/default/components/filter_cbox.py
@@ -2,6 +2,9 @@ from PyQt5.QtWidgets import QVBoxLayout, QHBoxLayout, QWidget
 from PyQt5.QtWidgets import QComboBox, QStyledItemDelegate, QLabel
 from .collapsible_box import CollapsibleBox
 
+#TODO: verify import structur. Should get_tag function be called from routine_page.py/home_page.py?
+from ....factory import get_tag
+
 
 class BadgerFilterBox(CollapsibleBox):
 
@@ -72,3 +75,27 @@ class BadgerFilterBox(CollapsibleBox):
         vbox.addWidget(gain)
 
         self.setContentLayout(vbox)
+        
+    def select_machine(self, machine: str):
+        if machine == "":
+            self.reset_tags()
+            self.cb_obj.setCurrentIndex(-1)
+            self.cb_reg.setCurrentIndex(-1)
+            self.cb_gain.setCurrentIndex(-1)
+        else:
+            tag_dict = get_tag(machine)
+            self.reset_tags()
+            
+            self.cb_obj.addItems(tag_dict['objective'])
+            self.cb_reg.addItems(tag_dict['region'])
+            self.cb_gain.addItems(tag_dict['gain'])
+            
+            
+    def reset_tags(self):     
+            self.cb_obj.clear()
+            self.cb_reg.clear()
+            self.cb_gain.clear()
+            
+            self.cb_obj.addItem('')
+            self.cb_reg.addItem('')
+            self.cb_gain.addItem('')

--- a/src/badger/gui/default/components/routine_page.py
+++ b/src/badger/gui/default/components/routine_page.py
@@ -74,7 +74,7 @@ class BadgerRoutinePage(QWidget):
         vbox_meta.addWidget(name, alignment=Qt.AlignTop)
 
         # Tags
-        self.cbox_tags = cbox_tags = BadgerFilterBox(title=' Tags')
+        self.cbox_tags = cbox_tags = BadgerFilterBox(parent=None, title=" Tags", tags = self.machine_tags)
         if not strtobool(read_value('BADGER_ENABLE_ADVANCED')):
             cbox_tags.hide()
         vbox_meta.addWidget(cbox_tags, alignment=Qt.AlignTop)

--- a/src/badger/gui/default/components/routine_page.py
+++ b/src/badger/gui/default/components/routine_page.py
@@ -6,7 +6,7 @@ import sqlite3
 import numpy as np
 import pandas as pd
 from coolname import generate_slug
-from ....factory import list_algo, list_env, get_algo, get_env
+from ....factory import list_algo, list_env, list_tag, get_algo, get_env, get_tag
 from ....utils import ystring, load_config, config_list_to_dict, strtobool
 from ....core import normalize_routine, instantiate_env, list_scaling_func, get_scaling_default_params
 from ....db import save_routine, remove_routine
@@ -38,6 +38,7 @@ class BadgerRoutinePage(QWidget):
 
         self.algos = list_algo()
         self.envs = list_env()
+        self.machine_tags = list_tag()
         self.env = None
         self.routine = None
         self.script = ''
@@ -108,6 +109,8 @@ class BadgerRoutinePage(QWidget):
         self.env_box.btn_add_curr.clicked.connect(self.fill_curr_in_init_table)
         self.env_box.btn_clear.clicked.connect(self.clear_init_table)
         self.env_box.btn_add_row.clicked.connect(self.add_row_to_init_table)
+        self.cbox_tags.cb_mach.currentIndexChanged.connect(self.select_machine_tag)
+
 
     def refresh_ui(self, routine):
         self.routine = routine  # save routine for future reference
@@ -210,6 +213,11 @@ class BadgerRoutinePage(QWidget):
             tags = routine['config']['tags']
         except:
             tags = {}
+        try:
+            self.cbox_tags.cb_mach.setCurrentIndex(tags['machine'])
+            self.select_machine_tag(self.machine_tags.index(tags['machine']))
+        except:
+            self.cbox_tags.cb_mach.setCurrentIndex(0)
         try:
             self.cbox_tags.cb_obj.setCurrentText(tags['objective'])
         except:
@@ -431,6 +439,13 @@ class BadgerRoutinePage(QWidget):
         for col in range(table.columnCount()):
             item = QTableWidgetItem('')
             table.setItem(row_position, col, item)
+            
+    def select_machine_tag(self, i):
+        if i <= 0:
+            machine_tag = ""
+        else:
+            machine_tag = self.machine_tags[i-1] # empty string from Combobox not in machine_tags
+        self.cbox_tags.select_machine(machine_tag)   
 
     def open_playground(self):
         pass

--- a/src/badger/gui/default/pages/home_page.py
+++ b/src/badger/gui/default/pages/home_page.py
@@ -18,6 +18,7 @@ from ....db import import_routines, export_routines
 from ....archive import load_run, delete_run
 from ....utils import get_header, strtobool
 from ....settings import read_value
+from ....factory import get_tag, list_tag
 
 
 stylesheet = '''
@@ -44,6 +45,8 @@ class BadgerHomePage(QWidget):
         self.mode = 'regular'  # home page mode
         self.splitter_state = None  # store the run splitter state
         self.tab_state = None  # store the tabs state before creating new routine
+        
+        self.machine_tags = list_tag()
 
         self.init_ui()
         self.config_logic()
@@ -100,7 +103,7 @@ class BadgerHomePage(QWidget):
         vbox_routine.addWidget(panel_search)
 
         # Filters
-        self.filter_box = filter_box = BadgerFilterBox(self, title=' Filters')
+        self.filter_box = filter_box = BadgerFilterBox(self, parent=None, title=" Filters", tags = self.machine_tags)
         if not strtobool(read_value('BADGER_ENABLE_ADVANCED')):
             filter_box.hide()
         vbox_routine.addWidget(filter_box)
@@ -211,6 +214,8 @@ class BadgerHomePage(QWidget):
         self.run_table.cellClicked.connect(self.solution_selected)
         self.run_table.itemSelectionChanged.connect(self.table_selection_changed)
 
+        self.filter_box.cb_mach.currentIndexChanged.connect(self.select_machine_tag)
+        self.filter_box.cb_mach.currentIndexChanged.connect(self.refresh_routine_list)
         self.filter_box.cb_obj.currentIndexChanged.connect(self.refresh_routine_list)
         self.filter_box.cb_reg.currentIndexChanged.connect(self.refresh_routine_list)
         self.filter_box.cb_gain.currentIndexChanged.connect(self.refresh_routine_list)
@@ -304,12 +309,21 @@ class BadgerHomePage(QWidget):
                 _item.activate()
                 self.prev_routine = item
 
+    def select_machine_tag(self, i):
+        if i <= 0:
+            machine_tag = ""
+        else:
+            machine_tag = self.machine_tags[i-1] # empty string from Combobox not in machine_tags
+        self.filter_box.select_machine(machine_tag)  
+        
     def get_current_routines(self):
         keyword = self.sbar.text()
+        tag_mach = self.filter_box.cb_mach.currentText()
         tag_obj = self.filter_box.cb_obj.currentText()
         tag_reg = self.filter_box.cb_reg.currentText()
         tag_gain = self.filter_box.cb_gain.currentText()
         tags = {}
+        if tag_mach: tags['machine'] = tag_mach
         if tag_obj: tags['objective'] = tag_obj
         if tag_reg: tags['region'] = tag_reg
         if tag_gain: tags['gain'] = tag_gain


### PR DESCRIPTION
**Not tested**: Please review my issue #9  so I can test it on the latest version

# Execution

### what
- add another filter property _machine_ to the tags widget
- first filter _machine_ defines the combobox options of the other 3 properties (gain, region, objective)

### why
- different machines have different regions and objectives for their optimization routines
- the current filter options are limited to slac only

### how
- adjust the plugin loading
- adjust the class BadgerFilterBox to deal with another property which influences other properties
- adjust routine_page where filters are defined for chosen routine
- adjust home_page where the filters are applied to the list of routines


# Supporting information

### Badger Plugins

![file_structure](https://github.com/SLAC-ML/Badger/assets/12428111/c4775c67-e3e3-4cca-a7ca-8b5a776146e1)
The directory tags was added to Badger Plugins. As examples, LCLS and XFEL was added.


![files](https://github.com/SLAC-ML/Badger/assets/12428111/84b4598c-68a9-40d9-b325-57e49ace97a2)
The init file conatins of a dictionary which contain the tags. The configs file only defines name and badger-opt as dependency




closes #10 