### PR TITLE
Appearance: use environment object var as display name

### DIFF
--- a/src/badger/gui/default/components/routine_page.py
+++ b/src/badger/gui/default/components/routine_page.py
@@ -22,7 +22,7 @@ from ..windows.docs_window import BadgerDocsWindow
 from ..windows.lim_vrange_dialog import BadgerLimitVariableRangeDialog
 from .data_table import get_table_content_as_dict, set_init_data_table
 from ....settings import read_value
-from ....errors import BadgerRoutineError
+from ....errors import BadgerRoutineError, BadgerPluginNotFoundError
 
 
 CONS_RELATION_DICT = {
@@ -320,11 +320,12 @@ class BadgerRoutinePage(QWidget):
     def get_envs_human_readable(self):
         result = []
         for env in self.envs:
-            env_obj = get_env(env)
             try:
+                env_obj = get_env(env)
                 result.append(env_obj.name)
-            except AttributeError:
+            except (AttributeError, BadgerPluginNotFoundError) as e:
                 result.append(env)
+                
         return result
 
     def select_env(self, i):


### PR DESCRIPTION
**untested** as the current master version is not working for me

### what
- display human readable names for the Environment combobox

### why
- user is able to set the displayed name without restriction from filesystem naming
- what was the use of the object variable "name" in Environment anyway? Please correct me if I am wrong, but I could not find the purpose

### how
- load all environments from the env_list and gather "name" from each. gather all names into a list
- set modified list to GUI object for display
- catch a missing object variable or a faulty environment. object variable should not be mandatory and faulty environment will be handled when user loads it for usage

closes #14 